### PR TITLE
Update draft troops to use getPlayerBorderRegions

### DIFF
--- a/src/aiplayer.js
+++ b/src/aiplayer.js
@@ -22,10 +22,10 @@ class AIPlayer {
 
     selectRegionToDraft(regions, dominantContinentId) {
         var dominantContinent = continentFactory.getContinentInstanceById(dominantContinentId);
-        var regionsInDominantContinent = dominantContinent.getPlayerRegions(this.player);
+        var borderRegionsInDominantContinent = dominantContinent.getPlayerBorderRegions(this.player);
 
-        if (regionsInDominantContinent.length > 0) {
-            return regionsInDominantContinent[Math.floor(Math.random() * regionsInDominantContinent.length)];
+        if (borderRegionsInDominantContinent.length > 0) {
+            return borderRegionsInDominantContinent[Math.floor(Math.random() * borderRegionsInDominantContinent.length)];
         }
         return regions[Math.floor(Math.random() * regions.length)];
     }

--- a/src/continent.js
+++ b/src/continent.js
@@ -64,6 +64,11 @@ var Continent = function (row, col) {
         return playerRegionsInThisContinent;
     }
 
+    this.getPlayerBorderRegions = function(player) {
+        const playerRegions = this.getPlayerRegions(player);
+        return playerRegions.filter(region => region.hasAdjacentOpponentRegions());
+    }
+
     this.element = getContinentElement();
 
     /**

--- a/src/gamecontroller.js
+++ b/src/gamecontroller.js
@@ -44,7 +44,6 @@ var GameController = {
         if (playerInTurn.isAI) {
             var aiPlayer = AIPlayerFactory.GetAIPlayerInstance(playerInTurn, this);
             var battleActions = aiPlayer.executeTurn();
-            battleActions.forEach(action => action());
         }
 
         attackerSelection = null;

--- a/src/main.js
+++ b/src/main.js
@@ -17,6 +17,7 @@ window.resetGameBoard = function() {
     playerstats.resetAndStartTurn();
     playerstats.updateStats();
     deck.init();
+    gamecontroller.startAI();
 }
 
 /**

--- a/src/region.js
+++ b/src/region.js
@@ -246,6 +246,32 @@ function region(row, col, contobj) {
         can = can && defendY <= attackY + 1 && defendY >= attackY - 1;
         return can;
     }
+
+    /**
+     * Returns the adjacent regions of the current region in the current continent.
+     * @returns {Array} An array of adjacent regions.
+     */
+    this.getAdjacentRegionsInContinent = function() {
+        const regionRow = this.getRow();
+        const regionCol = this.getColumn();
+        const allRegions = continent.getRegions();
+
+        return allRegions.filter(r => {
+            const rowDiff = Math.abs(r.getRow() - regionRow);
+            const colDiff = Math.abs(r.getColumn() - regionCol);
+
+            return (rowDiff <= 1 && colDiff <= 1) && r !== this;
+        });
+    }
+
+    /**
+     * Checks if the region has adjacent opponent regions.
+     * @returns {boolean} True if the region has adjacent opponent regions, otherwise false.
+     */
+    this.hasAdjacentOpponentRegions = function() {
+        const adjacentRegions = this.getAdjacentRegionsInContinent();
+        return adjacentRegions.some(adjRegion => adjRegion.getPlayer() !== this.getPlayer());
+    }
 }
 
 /**


### PR DESCRIPTION
Add functionality to draft troops only to regions adjacent to opponent regions.

* **continent.js**
  - Add `getPlayerBorderRegions` method to return player regions adjacent to opponent regions.

* **aiplayer.js**
  - Update `selectRegionToDraft` method to use `getPlayerBorderRegions` instead of `getPlayerRegions`.

* **region.js**
  - Add `getAdjacentRegionsInContinent` method to return adjacent regions in the current continent.
  - Add `hasAdjacentOpponentRegions` method to check if a region has adjacent opponent regions.

* **gamecontroller.js**
  - Remove redundant code related to AI player actions.

* **main.js**
  - Add call to `startAI` method in `startGame` function.

