### PR TITLE
Update dominant continent logic for AI player

### DIFF
--- a/src/aiplayer.js
+++ b/src/aiplayer.js
@@ -43,10 +43,12 @@ class AIPlayer {
                 this.player
             );
     
-            adjacentOpponentRegions.forEach(adjRegion => {
+            adjacentOpponentRegions.some(adjRegion => {
                 if (region.getTroopCount() > adjRegion.getTroopCount()) {
                     battles.push({ attacker: region, defender: adjRegion });
+                    return true; // Stop further iterations
                 }
+                return false;
             });
         });
     
@@ -71,6 +73,7 @@ class AIPlayer {
 
     getDominantContinentId() {
         const continentCounts = {};
+        const playerContinents = new Set(this.player.getState().continents.map(continent => continent.getId()));
         this.player.getState().regions.forEach(region => {
             const continent = region.getContinent().getId();
             if (!continentCounts[continent]) {
@@ -82,7 +85,7 @@ class AIPlayer {
         let dominantContinent = null;
         let maxCount = 0;
         for (const continent in continentCounts) {
-            if (continentCounts[continent] > maxCount) {
+            if (continentCounts[continent] > maxCount && !playerContinents.has(continent)) {
                 maxCount = continentCounts[continent];
                 dominantContinent = continent;
             }


### PR DESCRIPTION
Update `getDominantContinentId` to find the next dominant continent where the player is not the owner but has the next most troops.

* **getDominantContinentId**
  - Add a check to exclude continents already owned by the player when determining the dominant continent.
  - Track continents owned by the player using a set.

* **selectBattles**
  - Use `some` instead of `forEach` to stop further iterations once a valid battle is found.

